### PR TITLE
implement ability to use external ip address and improved instructions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+# Byte-compiled / optimized / DLL files
+__pycache__/
+*.py[cod]

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ Plex to Letterboxd - Export your Plex watch history as Letterboxd csv format.
 """
 import xml.etree.ElementTree as ET
 import sys
-from utils.ui import print_title, print_token_instructions
+from utils.ui import print_title, print_address_instructions, print_token_instructions
 from plex_api.libraries import get_librarySectionID
 from plex_api.history import get_watch_history
 
@@ -13,16 +13,20 @@ def main() -> None:
     sys.stdout.reconfigure(encoding='utf-8')
 
     print_title("Plex to Letterboxd")
-    print_token_instructions()
+    
+    print_address_instructions()
+    address = input("\nPlease enter your plex server's ip address: ")
 
+
+    print_token_instructions()
     token = input("\nPlease enter your plex token: ")
 
-    librarySectionID = get_librarySectionID(token)
+    librarySectionID = get_librarySectionID(address, token)
 
     # TODO - Get list of users - accountId
     # https://plex.tv/api/users?X-Plex-Token=
 
-    watch_history_response  = get_watch_history(token, 1, librarySectionID)
+    watch_history_response  = get_watch_history(address, token, 1, librarySectionID)
 
     root  = ET.fromstring(watch_history_response.content)
 

--- a/main.py
+++ b/main.py
@@ -4,7 +4,7 @@ Plex to Letterboxd - Export your Plex watch history as Letterboxd csv format.
 """
 import xml.etree.ElementTree as ET
 import sys
-from utils.ui import print_title, print_address_instructions, print_token_instructions
+from utils.ui import print_title, print_local_or_remote, print_address_instructions, print_token_instructions
 from plex_api.libraries import get_librarySectionID
 from plex_api.history import get_watch_history
 
@@ -13,9 +13,19 @@ def main() -> None:
     sys.stdout.reconfigure(encoding='utf-8')
 
     print_title("Plex to Letterboxd")
-    
-    print_address_instructions()
-    address = input("\nPlease enter your plex server's ip address: ")
+
+    print_local_or_remote()
+    local_or_remote = input("\nPlease enter 1 or 2: ")
+
+    if local_or_remote == "1":
+        address = "localhost"
+    elif local_or_remote == "2":
+        print_address_instructions()
+        address = input("\nPlease enter your plex server's ip address: ")
+    else:
+        print("\nInvalid selection. Please enter 1 or 2.")
+        sys.exit(1)
+   
 
 
     print_token_instructions()

--- a/plex_api/history.py
+++ b/plex_api/history.py
@@ -1,7 +1,7 @@
 """Plex watch history functionality."""
 from .client import get_plex_response
 
-def get_watch_history(token: str, accountID: str, librarySectionID: str) -> str:
+def get_watch_history(address: str, token: str, accountID: str, librarySectionID: str) -> str:
     """Return list of media watched by a given user in a library.
     
     Args:
@@ -12,7 +12,7 @@ def get_watch_history(token: str, accountID: str, librarySectionID: str) -> str:
     Returns:
         Response object containing watch history data
     """
-    url = f"http://localhost:32400/status/sessions/history/all?accountId={accountID}&librarySectionID={librarySectionID}&X-Plex-Token="
+    url = f"http://{address}:32400/status/sessions/history/all?accountId={accountID}&librarySectionID={librarySectionID}&X-Plex-Token="
     history_response = get_plex_response(url, token)
     
     return history_response

--- a/plex_api/libraries.py
+++ b/plex_api/libraries.py
@@ -2,7 +2,9 @@
 import xml.etree.ElementTree as ET
 from .client import get_plex_response
 
-def get_librarySectionID(token: str, lib_type: str = "movie") -> str:
+def get_librarySectionID(address: str, token: str, lib_type: str = "movie") -> str:
+    print(f"ADDRESS: {address}")
+    print(f"TOKEN {token}")
     """Return section key for a requested library.
     
         Args:
@@ -12,7 +14,8 @@ def get_librarySectionID(token: str, lib_type: str = "movie") -> str:
     Returns:
         The library section ID as a string
     """
-    list_res = get_plex_response("http://localhost:32400/library/sections?X-Plex-Token=", token)
+    url = f"http://{address}:32400/library/sections?X-Plex-Token="
+    list_res = get_plex_response(url, token)
     print("\nSuccess! Listing media libraries below.\n")
 
     root  = ET.fromstring(list_res.content)

--- a/utils/ui.py
+++ b/utils/ui.py
@@ -8,7 +8,14 @@ def print_title(title: str, line_length: int = 70) -> None:
     print(f"{'-' * title_spacing}{title}{'-' * title_spacing}")
     print(f"{'=' * line_length}")
 
+def print_local_or_remote() -> None:
+  """Prints instructions for local or remote access to Plex server."""
+  instructions = """Is your Plex server on a local network or remote?
 
+1. Local network (same home/office as you)
+2. Remote (accessing from outside your home/office)
+"""
+  print(instructions)
 
 def print_address_instructions() -> None:
   """Prints instructions for finding the Plex servers ip address."""
@@ -16,13 +23,6 @@ def print_address_instructions() -> None:
 PLEX SEVER ADDRESS INSTRUCTIONS:
 -----------------------
 To find your Plex server's IP address, you can use the following methods:
-
-======= Local Network Instructions =======
-1. Open a web browser and go to `https://app.plex.tv/desktop/`
-2. Sign in with your Plex account
-3. Click on Settings (wrench icon) in the top-right corner
-4. In the left sidebar, select "Remote Access"
-5. Look for the "Private IP address" listed on this page (format: 192.168.x.x)
 
 ======= External/Remote Access Instructions =======
 1. Log into your Plex account at `https://app.plex.tv/desktop/`

--- a/utils/ui.py
+++ b/utils/ui.py
@@ -9,6 +9,41 @@ def print_title(title: str, line_length: int = 70) -> None:
     print(f"{'=' * line_length}")
 
 
+
+def print_address_instructions() -> None:
+  """Prints instructions for finding the Plex servers ip address."""
+  instructions ="""
+PLEX SEVER ADDRESS INSTRUCTIONS:
+-----------------------
+To find your Plex server's IP address, you can use the following methods:
+
+======= Local Network Instructions =======
+1. Open a web browser and go to `https://app.plex.tv/desktop/`
+2. Sign in with your Plex account
+3. Click on Settings (wrench icon) in the top-right corner
+4. In the left sidebar, select "Remote Access"
+5. Look for the "Private IP address" listed on this page (format: 192.168.x.x)
+
+======= External/Remote Access Instructions =======
+1. Log into your Plex account at `https://app.plex.tv/desktop/`
+2. Click on Settings (wrench icon) in the top-right corner
+3. In the left sidebar, select "Remote Access"
+4. Check if "Remote Access" is enabled
+5. If enabled, look for "Public IP address" listed on this page
+   - This is your external IP that can be used outside your local network
+6. Note the port number listed (default is 32400)
+7. Your remote Plex URL will be: `http://YOUR_PUBLIC_IP:PORT_NUMBER`
+
+======= Troubleshooting =======
+- If remote access shows as "Not available outside your network", you need to:
+  1. Configure port forwarding on your router (port 32400)
+  2. Check firewall settings to allow Plex traffic
+  3. Ensure your ISP isn't blocking the required ports
+
+- For secure remote access, consider using Plex's relay service or setting up a VPN
+"""
+  print(instructions)
+
 def print_token_instructions() -> None:
     """Prints instructions for finding the Plex authentication token."""
     instructions = """


### PR DESCRIPTION
# Implement ability to use external ip address and improved instructions

## Changes made:
- Users can now pass in any ip address. allowing people to connect to remote plex servers

- Split the print_address_instructions() function into separate functions for local and remote scenarios:
  - print_local_instructions():  **Displays steps for finding Plex server IP on a local network
  - print_remote_instructions(): // Displays steps for finding Plex server IP for remote access
 
- Added command line methods to the local instructions for technical users
- Enhanced function docstrings for better code readability

